### PR TITLE
inline c code

### DIFF
--- a/cmd/bait.bait
+++ b/cmd/bait.bait
@@ -49,6 +49,22 @@ fun run_tests(args []string, prefs pref.Preferences) i32 {
 }
 
 fun compile(prefs pref.Preferences) i32 {
+	paths := bait_files_from_dir(os.resource_abs_path('lib/builtin'))
 	// TODO
 	return 1
+}
+
+fun bait_files_from_dir(dir string) []string {
+	all_files := os.ls(dir)
+	files := []string
+	for i := 0; i <all_files.len ; i += 1 {
+		f := all_files[i]
+		if f.ends_with('_test.bait') {
+			continue
+		}
+		if f.ends_with('.bait') {
+			files.push(dir + '/' + f)
+		}
+	}
+	return files
 }

--- a/cmd/main.v
+++ b/cmd/main.v
@@ -29,7 +29,7 @@ fn main() {
 		}
 		else {}
 	}
-	if command.ends_with('.bait') || os.exists(command) {
+	if command.ends_with('.bait') || os.is_dir(command) {
 		exit(compile(command, prefs))
 	}
 	eprintln('Unknown command: `bait $command`')

--- a/lib/bait/ast/ast.v
+++ b/lib/bait/ast/ast.v
@@ -23,6 +23,7 @@ pub type Stmt = AssertStmt
 	| TypeDecl
 pub type Expr = ArrayInit
 	| BoolLiteral
+	| CBlock
 	| CallExpr
 	| CastExpr
 	| CharLiteral
@@ -177,6 +178,11 @@ pub mut:
 pub struct BoolLiteral {
 pub:
 	val bool
+}
+
+pub struct CBlock {
+pub:
+	val string
 }
 
 pub struct CallExpr {

--- a/lib/bait/checker/checker.v
+++ b/lib/bait/checker/checker.v
@@ -58,6 +58,7 @@ fn (mut c Checker) expr(mut node ast.Expr) ast.Type {
 		ast.EmptyExpr { panic('found empty expr') }
 		ast.ArrayInit { return c.array_init(mut node) }
 		ast.BoolLiteral { return ast.bool_type }
+		ast.CBlock {} // unsafe code that cannot be checked
 		ast.CallExpr { return c.call_expr(mut node) }
 		ast.CastExpr { return c.cast_expr(mut node) }
 		ast.CharLiteral { return ast.u8_type }

--- a/lib/bait/gen/c/cgen.v
+++ b/lib/bait/gen/c/cgen.v
@@ -230,6 +230,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 		ast.EmptyExpr { panic('found empty expr') }
 		ast.ArrayInit { g.array_init(node) }
 		ast.BoolLiteral { g.bool_literal(node) }
+		ast.CBlock { g.c_block(node) }
 		ast.CallExpr { g.call_expr(node) }
 		ast.CastExpr { g.cast_expr(node) }
 		ast.CharLiteral { g.char_literal(node) }
@@ -464,6 +465,10 @@ fn (mut g Gen) array_init(node ast.ArrayInit) {
 
 fn (mut g Gen) bool_literal(node ast.BoolLiteral) {
 	g.write('$node.val')
+}
+
+fn (mut g Gen) c_block(node ast.CBlock) {
+	g.writeln(node.val)
 }
 
 fn (mut g Gen) call_expr(node ast.CallExpr) {

--- a/lib/bait/gen/c/cheaders.v
+++ b/lib/bait/gen/c/cheaders.v
@@ -9,6 +9,7 @@ const c_includes = '#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <dirent.h>
 '
 
 const c_builtin_types = 'typedef int8_t i8;

--- a/lib/bait/parser/expr.v
+++ b/lib/bait/parser/expr.v
@@ -289,6 +289,14 @@ fn (mut p Parser) infix_expr(left ast.Expr) ast.InfixExpr {
 	}
 }
 
+fn (mut p Parser) c_block() ast.CBlock {
+	val := p.tok.lit
+	p.next()
+	return ast.CBlock{
+		val: val
+	}
+}
+
 fn (mut p Parser) map_init() ast.MapInit {
 	p.check(.lcur)
 	mut keys := []ast.Expr{}
@@ -355,6 +363,9 @@ fn (mut p Parser) name_expr() ast.Expr {
 		p.expr_pkg = p.tok.lit
 		p.next()
 		p.check(.dot)
+	}
+	if lang == .c && p.tok.kind == .string {
+		return p.c_block()
 	}
 	if p.peek_tok.kind == .lpar {
 		if p.tok.lit in p.table.type_idxs {

--- a/lib/os/os.bait
+++ b/lib/os/os.bait
@@ -53,6 +53,16 @@ fun real_path(path string) string {
 	return res.cstring_to_string()
 }
 
+fun resource_abs_path(path string) string {
+	env_resource := getenv('BAIT_RESOURCE_PATH')
+	if env_resource.len != 0 {
+		return real_path(env_resource + '/' + path)
+	}
+	exe := executable()
+	base_path := real_path(dir(exe))
+	return real_path(base_path + '/' + path)
+}
+
 fun executable()string{
 	result := &u8(calloc(4096))
 	count := i32(C.readlink('/proc/self/exe', result, 4096))
@@ -61,6 +71,10 @@ fun executable()string{
 
 fun exists(path string) bool {
 	return C.access(path.str, 0) != -1
+}
+
+fun ls(dir string)[]string {
+	// TODO
 }
 
 fun read_file(path string) string {


### PR DESCRIPTION
- add inline c code like `C.'int x;'`
- fix running bait with exectuable as input file
- add function to os: resource_abs_path(path)