### PR TITLE
genbaitjs: prevent running outside of CI

### DIFF
--- a/cli/tools/gen-baitjs.bt
+++ b/cli/tools/gen-baitjs.bt
@@ -10,6 +10,12 @@ const GIT_MAIL := '131296262+tiabeast-bot@users.noreply.github.com'
 const MAIN_REPO_COMMIT_URL := 'https://github.com/tiabeast/bait/commit'
 
 fun main() {
+	is_ci := os.getenv('CI') == 'true'
+	if not is_ci {
+		eprintln('gen-baitjs is only meant to be run in CI.')
+		exit(1)
+	}
+
 	os.system('git config --global user.name "${GIT_USER}"')
 	os.system('git config --global user.email "${GIT_MAIL}"')
 

--- a/lib/os/os.bt
+++ b/lib/os/os.bt
@@ -107,7 +107,10 @@ pub fun resource_abs_path(path string) string {
 }
 
 pub fun getenv(key string) string {
-	return from_js_string(#JS.'process.env[key.str]')
+	if #JS.'process.env[key.str]' {
+		return from_js_string(#JS.'process.env[key.str]')
+	}
+	return ''
 }
 
 pub fun setenv(key string, value string) {


### PR DESCRIPTION
> `export CI=true && node bait.js gen-baitjs` will still work.

