### PR TITLE
checker: detect nonexistent generic type names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin/
 
 # editor files
 *.code-workspace
+*.vscode

--- a/lib/bait/ast/ast.bt
+++ b/lib/bait/ast/ast.bt
@@ -162,6 +162,7 @@ pub:
 	name string
 	typ Type
 	fields []StructField
+	generic_names []string
 	pos token.Pos
 }
 

--- a/lib/bait/checker/checker.bt
+++ b/lib/bait/checker/checker.bt
@@ -21,6 +21,7 @@ mut:
 	cur_fun ast.FunDecl
 	cur_concrete_types []ast.Type
 	need_generic_resolve bool
+	cur_generic_names []string
 	expected_type ast.Type
 	is_lhs_assign bool
 	is_if_match_expr bool

--- a/lib/bait/checker/fun.bt
+++ b/lib/bait/checker/fun.bt
@@ -63,10 +63,15 @@ fun (mut c Checker) fun_instance(mut node ast.FunDecl) {
 	c.cur_fun = node
 	c.check_fun_attrs(mut node) // FIXME this should error because node is not mut
 
+	// save current generic names in outer scope and override them with
+	// the funs' generic names (so does_type_exist can detect nonexistent generic names)
+	prev_generic_names := c.cur_generic_names
+	c.cur_generic_names = node.generic_names
 	c.open_scope()
 	c.fun_params(node.params)
 	c.stmts(node.stmts)
 	c.close_scope()
+	c.cur_generic_names = prev_generic_names
 
 	ret_sym := c.table.get_sym(node.return_type)
 	is_void := node.return_type == ast.VOID_TYPE or ret_sym.parent == ast.VOID_TYPE

--- a/lib/bait/checker/struct.bt
+++ b/lib/bait/checker/struct.bt
@@ -10,6 +10,12 @@ fun (mut c Checker) struct_decl(node ast.StructDecl) {
 	// TODO remove exceptions for string and map
 	// TODO error
 	// TODO test
+
+	// save current generic names and override them with the structs' generic names
+	// so does_type_exist can detect nonexistent generic names
+	prev_generic_names := c.cur_generic_names
+	c.cur_generic_names = node.generic_names
+	
 	if not node.name[0].is_upper() and node.name != 'string' and node.name != 'map' {
 		c.warn('struct name `${node.name}` must start with a capital letter', node.pos)
 	}
@@ -39,6 +45,8 @@ fun (mut c Checker) struct_decl(node ast.StructDecl) {
 			c.error('default value not matches field type ${c.table.type_name(field.typ)}', (field.expr as ast.EmptyExpr).pos)
 		}
 	}
+
+	c.cur_generic_names = prev_generic_names
 }
 
 fun (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {

--- a/lib/bait/checker/type.bt
+++ b/lib/bait/checker/type.bt
@@ -81,7 +81,7 @@ fun (c Checker) check_types(got ast.Type, expected ast.Type) bool {
 }
 
 fun (c Checker) does_type_exist(sym ast.TypeSymbol, pos token.Pos) bool {
-	if sym.kind == .placeholder and sym.name != '_' {
+	if (sym.kind == .placeholder and sym.name != '_') or (sym.kind == .generic and not (c.cur_generic_names.contains(sym.name))) {
 		c.error('unknown type ${sym.name}', pos)
 		return false
 	}

--- a/lib/bait/parser/struct.bt
+++ b/lib/bait/parser/struct.bt
@@ -105,6 +105,7 @@ fun (mut p Parser) struct_decl() !ast.StructDecl{
 		name = name
 		typ = typ
 		fields = fields
+		generic_names = generic_names
 		pos = pos
 	}
 }

--- a/tests/out/error/generics/nonexistent_generic_sym.in.bt
+++ b/tests/out/error/generics/nonexistent_generic_sym.in.bt
@@ -1,0 +1,12 @@
+// This adds a new .generic TypeSymbol `T` to the table
+fun define_t[T]() {}
+// the table still has T!
+
+fun max(x T, y T) T {
+    return if x > y { x } else { y }
+}
+
+fun test_nonexistent_generic_sym() {
+    x := max(5, 6)
+    println(typeof(x))
+}

--- a/tests/out/error/generics/nonexistent_generic_sym.out
+++ b/tests/out/error/generics/nonexistent_generic_sym.out
@@ -1,0 +1,5 @@
+tests/out/error/generics/nonexistent_generic_sym.in.bt:5:9 error: unknown type T
+tests/out/error/generics/nonexistent_generic_sym.in.bt:5:14 error: unknown type T
+tests/out/error/generics/nonexistent_generic_sym.in.bt:6:15 error: undefined identifier x
+tests/out/error/generics/nonexistent_generic_sym.in.bt:6:23 error: undefined identifier x
+tests/out/error/generics/nonexistent_generic_sym.in.bt:6:34 error: undefined identifier y


### PR DESCRIPTION
When anything adds a new generic symbol to the table, does_type_exist will always find it, even in other functions that don't have the same generic name. This commit fixes that by introducing a variable `cur_generic_names` in the checker so `does_type_exist` can check if a given generic name exists in the scope of the current function/struct.

Behaviour before the changes:

```kt
// This adds a new .generic TypeSymbol `T` to the table
fun define_t[T]() {}
// the table still has T!

// No `[T]` here, but no errors!
fun max(x T, y T) T {
    return if x > y { x } else { y }
}

fun main() {
    x := max(5, 6)
    println(typeof(x)) // T
    println(x) // error: cannot convert _ to string
}
```

After:

```
test.bt:6:9 error: unknown type T
test.bt:6:14 error: unknown type T
test.bt:7:15 error: undefined identifier x
test.bt:7:23 error: undefined identifier x
test.bt:7:34 error: undefined identifier y
```