### PR TITLE
parser: deprecate struct/interface field modifier groups

### DIFF
--- a/lib/bait/parser/stmt.bt
+++ b/lib/bait/parser/stmt.bt
@@ -303,6 +303,7 @@ fun (mut p Parser) interface_decl() !ast.InterfaceDecl{
 	mut pub_idx := -1
 	mut pub_mut_idx := -1
 	mut global_idx := -1
+	mut one_time_pub := false
 	mut field_is_mut := false
 	mut field_is_pub := false
 	mut field_is_global := false
@@ -312,7 +313,7 @@ fun (mut p Parser) interface_decl() !ast.InterfaceDecl{
 
 	p.check(.lcur)!
 	for p.tok != .rcur {
-		if p.tok == .key_mut {
+		if p.tok == .key_mut and p.peek() == .colon {
 			if mut_idx != -1 {
 				p.error('redefinition of "mut" section')!
 				return ast.InterfaceDecl{}
@@ -325,7 +326,7 @@ fun (mut p Parser) interface_decl() !ast.InterfaceDecl{
 			field_is_global = false
 		} else if p.tok == .key_pub {
 			p.next()
-			if p.tok == .key_mut {
+			if p.tok == .key_mut and p.peek() == .colon {
 				if pub_mut_idx != -1 {
 					p.error('redefinition of "pub mut" section')!
 					return ast.InterfaceDecl{}
@@ -335,7 +336,8 @@ fun (mut p Parser) interface_decl() !ast.InterfaceDecl{
 				field_is_mut = true
 				field_is_pub = true
 				field_is_global = false
-			} else {
+				p.check(.colon)!
+			} else if p.tok == .colon {
 				if pub_idx != -1 {
 					p.error('redefinition of "pub" section')!
 					return ast.InterfaceDecl{}
@@ -344,9 +346,11 @@ fun (mut p Parser) interface_decl() !ast.InterfaceDecl{
 				field_is_mut = false
 				field_is_pub = true
 				field_is_global = false
+				p.check(.colon)!
+			} else {
+				one_time_pub = true
 			}
-			p.check(.colon)!
-		} else if p.tok == .key_global {
+		} else if p.tok == .key_global and p.peek() == .colon {
 			if global_idx != -1 {
 				p.error('redefinition of "global" section')!
 				return ast.InterfaceDecl{}
@@ -357,6 +361,23 @@ fun (mut p Parser) interface_decl() !ast.InterfaceDecl{
 			field_is_mut = true
 			field_is_pub = true
 			field_is_global = true
+		}
+
+		mut pub2 := field_is_pub
+		mut mut2 := field_is_mut
+		mut glob2 := field_is_global
+
+		if p.tok == .key_pub {
+			p.next()
+			pub2 = true
+		}
+		if p.tok == .key_mut {
+			p.next()
+			mut2 = true
+		}
+		if p.tok == .key_global {
+			p.next()
+			glob2 = true
 		}
 
 		fname := p.check_name()!
@@ -370,10 +391,12 @@ fun (mut p Parser) interface_decl() !ast.InterfaceDecl{
 		fields.push(ast.StructField{
 			name = fname
 			typ = p.parse_type()!
-			is_mut = field_is_mut
-			is_pub = field_is_pub
-			is_global = field_is_global
+			is_mut = mut2
+			is_pub = pub2 or one_time_pub
+			is_global = glob2
 		})
+
+		one_time_pub = false
 	}
 	p.next()
 

--- a/lib/bait/parser/stmt.bt
+++ b/lib/bait/parser/stmt.bt
@@ -299,6 +299,7 @@ fun (mut p Parser) interface_decl() !ast.InterfaceDecl{
 	}
 	typ := p.table.register_sym(tsym)
 
+	// TODO DEPRECATED 2024-11-03 remove code for modifier groups
 	mut mut_idx := -1
 	mut pub_idx := -1
 	mut pub_mut_idx := -1

--- a/lib/bait/parser/stmt.bt
+++ b/lib/bait/parser/stmt.bt
@@ -314,6 +314,7 @@ fun (mut p Parser) interface_decl() !ast.InterfaceDecl{
 	p.check(.lcur)!
 	for p.tok != .rcur {
 		if p.tok == .key_mut and p.peek() == .colon {
+			p.warn('Modifier groups are deprecated. Please define modifiers per field')
 			if mut_idx != -1 {
 				p.error('redefinition of "mut" section')!
 				return ast.InterfaceDecl{}
@@ -327,6 +328,7 @@ fun (mut p Parser) interface_decl() !ast.InterfaceDecl{
 		} else if p.tok == .key_pub {
 			p.next()
 			if p.tok == .key_mut and p.peek() == .colon {
+				p.warn('Modifier groups are deprecated. Please define modifiers per field')
 				if pub_mut_idx != -1 {
 					p.error('redefinition of "pub mut" section')!
 					return ast.InterfaceDecl{}
@@ -338,6 +340,7 @@ fun (mut p Parser) interface_decl() !ast.InterfaceDecl{
 				field_is_global = false
 				p.check(.colon)!
 			} else if p.tok == .colon {
+				p.warn('Modifier groups are deprecated. Please define modifiers per field')
 				if pub_idx != -1 {
 					p.error('redefinition of "pub" section')!
 					return ast.InterfaceDecl{}
@@ -351,6 +354,7 @@ fun (mut p Parser) interface_decl() !ast.InterfaceDecl{
 				one_time_pub = true
 			}
 		} else if p.tok == .key_global and p.peek() == .colon {
+			p.warn('Modifier groups are deprecated. Please define modifiers per field')
 			if global_idx != -1 {
 				p.error('redefinition of "global" section')!
 				return ast.InterfaceDecl{}

--- a/lib/bait/parser/struct.bt
+++ b/lib/bait/parser/struct.bt
@@ -22,6 +22,7 @@ fun (mut p Parser) struct_decl() !ast.StructDecl{
 	mut pub_idx := -1
 	mut pub_mut_idx := -1
 	mut global_idx := -1
+	mut one_time_pub := false
 	mut field_is_mut := false
 	mut field_is_pub := false
 	mut field_is_global := false
@@ -29,7 +30,7 @@ fun (mut p Parser) struct_decl() !ast.StructDecl{
 
 	p.check(.lcur)!
 	for p.tok != .rcur {
-		if p.tok == .key_mut {
+		if p.tok == .key_mut and p.peek() == .colon {
 			if mut_idx != -1 {
 				p.error('redefinition of "mut" section')!
 				return ast.StructDecl{}
@@ -42,7 +43,7 @@ fun (mut p Parser) struct_decl() !ast.StructDecl{
 			field_is_global = false
 		} else if p.tok == .key_pub {
 			p.next()
-			if p.tok == .key_mut {
+			if p.tok == .key_mut and p.peek() == .colon {
 				if pub_mut_idx != -1 {
 					p.error('redefinition of "pub mut" section')!
 					return ast.StructDecl{}
@@ -52,7 +53,8 @@ fun (mut p Parser) struct_decl() !ast.StructDecl{
 				field_is_mut = true
 				field_is_pub = true
 				field_is_global = false
-			} else {
+				p.check(.colon)!
+			} else if p.tok == .colon {
 				if pub_idx != -1 {
 					p.error('redefinition of "pub" section')!
 					return ast.StructDecl{}
@@ -61,9 +63,11 @@ fun (mut p Parser) struct_decl() !ast.StructDecl{
 				field_is_mut = false
 				field_is_pub = true
 				field_is_global = false
+				p.check(.colon)!
+			} else {
+				one_time_pub = true
 			}
-			p.check(.colon)!
-		} else if p.tok == .key_global {
+		} else if p.tok == .key_global and p.peek() == .colon {
 			if global_idx != -1 {
 				p.error('redefinition of "global" section')!
 				return ast.StructDecl{}
@@ -77,7 +81,8 @@ fun (mut p Parser) struct_decl() !ast.StructDecl{
 		}
 
 		p.parse_attributes()!
-		fields.push(p.struct_decl_field(field_is_mut, field_is_pub, field_is_global)!)
+		fields.push(p.struct_decl_field(field_is_mut, field_is_pub or one_time_pub, field_is_global)!)
+		one_time_pub = false
 	}
 	p.check(.rcur)!
 
@@ -112,6 +117,24 @@ fun (mut p Parser) struct_decl() !ast.StructDecl{
 
 fun (mut p Parser) struct_decl_field(is_mut bool, is_pub bool, is_global bool) !ast.StructField {
 	pos := p.pos
+
+	mut pub2 := is_pub
+	mut mut2 := is_mut
+	mut glob2 := is_global
+
+	if p.tok == .key_pub {
+		p.next()
+		pub2 = true
+	}
+	if p.tok == .key_mut {
+		p.next()
+		mut2 = true
+	}
+	if p.tok == .key_global {
+		p.next()
+		glob2 = true
+	}
+
 	fname := p.check_name()!
 	ftyp := p.parse_type()!
 	mut expr := ast.EmptyExpr{} as ast.Expr
@@ -124,9 +147,9 @@ fun (mut p Parser) struct_decl_field(is_mut bool, is_pub bool, is_global bool) !
 		typ = ftyp
 		expr = expr
 		pos = pos
-		is_mut = is_mut
-		is_pub = is_pub
-		is_global = is_global
+		is_mut = mut2
+		is_pub = pub2
+		is_global = glob2
 		attrs = p.attributes
 	}
 

--- a/lib/bait/parser/struct.bt
+++ b/lib/bait/parser/struct.bt
@@ -31,6 +31,7 @@ fun (mut p Parser) struct_decl() !ast.StructDecl{
 	p.check(.lcur)!
 	for p.tok != .rcur {
 		if p.tok == .key_mut and p.peek() == .colon {
+			p.warn('Modifier groups are deprecated. Please define modifiers per field')
 			if mut_idx != -1 {
 				p.error('redefinition of "mut" section')!
 				return ast.StructDecl{}
@@ -44,6 +45,7 @@ fun (mut p Parser) struct_decl() !ast.StructDecl{
 		} else if p.tok == .key_pub {
 			p.next()
 			if p.tok == .key_mut and p.peek() == .colon {
+				p.warn('Modifier groups are deprecated. Please define modifiers per field')
 				if pub_mut_idx != -1 {
 					p.error('redefinition of "pub mut" section')!
 					return ast.StructDecl{}
@@ -55,6 +57,7 @@ fun (mut p Parser) struct_decl() !ast.StructDecl{
 				field_is_global = false
 				p.check(.colon)!
 			} else if p.tok == .colon {
+				p.warn('Modifier groups are deprecated. Please define modifiers per field')
 				if pub_idx != -1 {
 					p.error('redefinition of "pub" section')!
 					return ast.StructDecl{}
@@ -68,6 +71,7 @@ fun (mut p Parser) struct_decl() !ast.StructDecl{
 				one_time_pub = true
 			}
 		} else if p.tok == .key_global and p.peek() == .colon {
+			p.warn('Modifier groups are deprecated. Please define modifiers per field')
 			if global_idx != -1 {
 				p.error('redefinition of "global" section')!
 				return ast.StructDecl{}

--- a/lib/bait/parser/struct.bt
+++ b/lib/bait/parser/struct.bt
@@ -18,6 +18,7 @@ fun (mut p Parser) struct_decl() !ast.StructDecl{
 
 	generic_names := p.generic_type_names()!
 
+	// TODO DEPRECATED 2024-11-03 remove code for modifier groups
 	mut mut_idx := -1
 	mut pub_idx := -1
 	mut pub_mut_idx := -1


### PR DESCRIPTION
This current syntax is being deprecated and will be removed in three days (2024-11-03):
```bait
struct Foo{
pub:
    x i32
    // ...
mut:
    y i32
    // ...
pub mut:
    z string
    // ...
global:
    g bool
    // ...
}
```

in favor of this new syntax:
```bait
struct Foo{
	pub x i32
	mut y i32
	pub mut z string
	global g bool
        // ...
}
```

The parser now supports both ways and shows deprecation warnings.
The removal of the old syntax is planned for the coming days.

#### Reasoning
- Fields had to be grouped by modifier which sometimes breaks up logically related fields that could be next together
- Changing the modifier of a field involved moving the whole line around
- Downside: more keystrokes due to increased amount of typing modifiers