### PR TITLE
parser: `&` PrefixExpr

### DIFF
--- a/lib/bait/parser/expr.bt
+++ b/lib/bait/parser/expr.bt
@@ -70,7 +70,7 @@ fun (mut p Parser) single_expr() !ast.Expr {
 		.key_mut {
 			return p.ident(.bait)!
 		}
-		.key_not, .minus, .mul, .tilde {
+		.amp, .key_not, .minus, .mul, .tilde {
 			return p.prefix_expr()!
 		}
 		.key_typeof {


### PR DESCRIPTION
Note: gen.c lacks support