### PR TITLE
core: deprecate `global` in favor of `static` for toplevel variables

### DIFF
--- a/docs/design/syntax.md
+++ b/docs/design/syntax.md
@@ -21,3 +21,17 @@ Why is the syntax the way it is?
 ### References
 - [Discord: Thoughts by @zeozeozeo](https://discord.com/channels/1204569231992295494/1204741190432325652/1302526862982905866)
 - [soc.me: `ident: Type` over `Type ident`](https://soc.me/languages/type-annotations)
+
+
+## Static Variables
+### Benefits
+- **No name collision** with symbols in other packages
+- **Clear scope** and explicit usage
+
+### Alternatives considered
+- Global variables
+  - Hard to trace where a variable and value changes come from
+  - Unintended coupling of independent code parts
+
+### References
+- [GH-249 by @StunxFS](https://github.com/bait-lang/bait/issues/249)

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -560,14 +560,22 @@ The following conditions are currently supported:
 | --------- | ------------------ |
 | `C`, `JS` | `LINUX`, `WINDOWS` |
 
-## Global Variables
-While the use of global variables is discouraged, they are important in some cases.
 
-> 🚧 In a future version, global variables will require a compiler flag to be enabled.
+## Static Variables
+While Bait has no support for global variables, you can use static package variables for a similar purpose.
 
 ```bait
-global my_global := 123
+static my_static_var := 123
 ```
+
+They are public and mutable from everywhere:
+```bait
+import bait.test_pkgs.demo
+
+demo.shared_var += 7
+println(demo.shared_var) // 130
+```
+
 
 ## Calling JavaScript from Bait
 ### JS Imports and Declarations

--- a/lib/bait/ast/ast.bt
+++ b/lib/bait/ast/ast.bt
@@ -5,7 +5,7 @@ package ast
 import bait.token
 import bait.errors
 
-type Stmt := AssertStmt | AssignStmt | ConstDecl | EnumDecl | ExprStmt | ForLoop | ForClassicLoop | ForInLoop | FunDecl | GlobalDecl | InterfaceDecl | ReturnStmt | StructDecl | TypeDecl | LoopControlStmt | IfMatch | InvalidStmt
+type Stmt := AssertStmt | AssignStmt | ConstDecl | EnumDecl | ExprStmt | ForLoop | ForClassicLoop | ForInLoop | FunDecl | StaticDecl | InterfaceDecl | ReturnStmt | StructDecl | TypeDecl | LoopControlStmt | IfMatch | InvalidStmt
 
 type Expr := AnonFun | ArrayInit | AsCast | BoolLiteral | CallExpr | CharLiteral | ComptimeVar | EnumVal | FloatLiteral | HashExpr | Ident | IfMatch | IndexExpr | InfixExpr | IntegerLiteral | MapInit | ParExpr | PrefixExpr | SelectorExpr | StringLiteral | StringInterLiteral | StructInit | TypeOf | Void | InvalidExpr
 
@@ -112,7 +112,7 @@ pub struct LoopControlStmt {
 	pub pos token.Pos
 }
 
-pub struct GlobalDecl {
+pub struct StaticDecl {
 	global typ Type
 	pub name string
 	pub pkg string

--- a/lib/bait/ast/scope.bt
+++ b/lib/bait/ast/scope.bt
@@ -21,9 +21,9 @@ pub enum ObjectKind {
 	variable
 	constant
 	function
-	global_
 	package_
 	label
+	static_
 }
 
 pub fun (mut t Table) preregister_scopes(pkg_name string) &Scope {

--- a/lib/bait/checker/expr.bt
+++ b/lib/bait/checker/expr.bt
@@ -178,7 +178,7 @@ fun (mut c Checker) ident(mut node ast.Ident) ast.Type {
 		obj.typ = c.expr(obj.expr)
 	}
 
-	if obj.kind == .constant or obj.kind == .global_ {
+	if obj.kind == .constant or obj.kind == .static_ {
 		if not node.name.contains('.') {
 			if obj.pkg == "" {
 				node.name = node.pkg + '.' + node.name

--- a/lib/bait/checker/stmt.bt
+++ b/lib/bait/checker/stmt.bt
@@ -22,7 +22,7 @@ fun (mut c Checker) stmt(mut stmt ast.Stmt){
 		ast.ForClassicLoop { c.for_classic_loop(stmt) }
 		ast.ForInLoop { c.for_in_loop(mut stmt) }
 		ast.FunDecl { c.fun_decl(mut stmt) }
-		ast.GlobalDecl { c.global_decl(mut stmt) }
+		ast.StaticDecl { c.static_decl(mut stmt) }
 		ast.IfMatch { c.if_match(mut stmt) }
 		ast.InterfaceDecl { c.interface_decl(stmt) }
 		ast.LoopControlStmt { c.loop_control_stmt(stmt) }
@@ -179,7 +179,7 @@ fun (mut c Checker) for_in_loop(mut node ast.ForInLoop) {
 	c.close_scope()
 }
 
-fun (mut c Checker) global_decl(mut node ast.GlobalDecl){
+fun (mut c Checker) static_decl(mut node ast.StaticDecl){
 	node.typ = c.expr(node.expr)
 	c.table.scopes[node.pkg].update_type(node.name, node.typ)
 }

--- a/lib/bait/gen/c/cgen.bt
+++ b/lib/bait/gen/c/cgen.bt
@@ -23,7 +23,7 @@ struct Gen {
 	mut fun_decls_out string := '// Function declarations\n'
 	mut type_impls_out string := '// Type implementations\n'
 	mut auto_funs_out string := '// Generated functions\n'
-	mut globals_out string := '// Globals\n'
+	mut globals_out string := '// Static variables\n'
 	mut out string := '// Main code\n'
 	mut indent i32 := -1
 	mut empty_line bool := true

--- a/lib/bait/gen/c/stmt.bt
+++ b/lib/bait/gen/c/stmt.bt
@@ -25,7 +25,7 @@ fun (mut g Gen) stmt(stmt ast.Stmt) {
 		ast.ForClassicLoop { g.for_classic_loop(stmt) }
 		ast.ForInLoop { g.for_in_loop(stmt) }
 		ast.FunDecl { g.fun_decl(stmt) }
-		ast.GlobalDecl { g.global_decl(stmt) }
+		ast.StaticDecl { g.static_decl(stmt) }
 		ast.IfMatch { g.if_match(stmt) }
 		ast.InterfaceDecl { g.interface_decl(stmt) }
 		ast.LoopControlStmt { g.loop_control_stmt(stmt) }
@@ -164,7 +164,7 @@ fun (mut g Gen) loop_control_stmt(node ast.LoopControlStmt){
 	g.writeln(node.kind.c_repr() + ';')
 }
 
-fun (mut g Gen) global_decl(node ast.GlobalDecl){
+fun (mut g Gen) static_decl(node ast.StaticDecl){
 	name := c_name(node.name)
 	pkg := c_name(node.pkg)
 	expr := g.expr_string(node.expr)

--- a/lib/bait/gen/js/stmt.bt
+++ b/lib/bait/gen/js/stmt.bt
@@ -39,8 +39,8 @@ fun (mut g Gen) stmt(stmt ast.Stmt) {
 		g.for_in_loop(stmt)
 	} else if stmt is ast.FunDecl {
 		g.fun_decl(stmt)
-	} else if stmt is ast.GlobalDecl {
-		g.global_decl(stmt)
+	} else if stmt is ast.StaticDecl {
+		g.static_decl(stmt)
 	} else if stmt is ast.IfMatch {
 		g.if_match(stmt)
 	} else if stmt is ast.InterfaceDecl {
@@ -295,7 +295,7 @@ fun (mut g Gen) for_in_map(node ast.ForInLoop){
 	g.writeln('}')
 }
 
-fun (mut g Gen) global_decl(node ast.GlobalDecl){
+fun (mut g Gen) static_decl(node ast.StaticDecl){
 	name := js_name(node.name)
 	pkg := js_name(node.pkg)
 	expr := g.expr_string(node.expr)

--- a/lib/bait/parser/stmt.bt
+++ b/lib/bait/parser/stmt.bt
@@ -12,8 +12,8 @@ fun (mut p Parser) toplevel_stmt() !ast.Stmt {
 		.key_const{ p.const_decl()! }
 		.key_enum{ p.enum_decl()! }
 		.key_fun{ p.fun_decl()! }
-		.key_global{ p.global_decl()! }
 		.key_interface{ p.interface_decl()! }
+		.key_static, .key_global{ p.static_decl()! } // TODO GLOBAL remove global
 		.key_struct{ p.struct_decl()! }
 		.key_type{ p.type_decl()! }
 		else { p.script_mode_or_error()! }
@@ -256,9 +256,14 @@ fun (mut p Parser) enum_decl() !ast.EnumDecl{
 	}
 }
 
-fun (mut p Parser) global_decl() !ast.GlobalDecl{
+fun (mut p Parser) static_decl() !ast.StaticDecl{
 	pos := p.pos
-	p.check(.key_global)!
+	if p.tok == .key_global {
+		p.warn("`global` will soon be removed, use `static` instead")
+		p.next()
+	} else {
+		p.check(.key_static)!
+	}
 	name := p.check_name()!
 	p.check(.decl_assign)!
 	expr := p.expr(.lowest)!
@@ -266,9 +271,9 @@ fun (mut p Parser) global_decl() !ast.GlobalDecl{
 	p.pkg_scope.register(name, ast.ScopeObject{
 		is_mut = true
 		typ = typ
-		kind = .global_
+		kind = .static_
 	})
-	return ast.GlobalDecl{
+	return ast.StaticDecl{
 		name = name
 		pkg = p.pkg_name
 		expr = expr

--- a/lib/bait/test_pkgs/demo/demo.bt
+++ b/lib/bait/test_pkgs/demo/demo.bt
@@ -1,0 +1,3 @@
+package demo
+
+static shared_var := 123

--- a/lib/bait/token/token.bt
+++ b/lib/bait/token/token.bt
@@ -80,6 +80,7 @@ pub enum Token {
 	key_package
 	key_pub
 	key_return
+	key_static
 	key_struct
 	key_true
 	key_type
@@ -112,6 +113,7 @@ pub fun kind_from_string(name string) Token {
 		'package' { .key_package }
 		'pub' { .key_pub }
 		'return' { .key_return }
+		'static' { .key_static }
 		'struct' { .key_struct }
 		'true' { .key_true }
 		'type' { .key_type }
@@ -277,6 +279,7 @@ pub fun (kind Token) str() string {
 		.key_package { 'key_package' }
 		.key_pub { 'key_pub' }
 		.key_return { 'key_return' }
+		.key_static { 'key_static' }
 		.key_struct { 'key_struct' }
 		.key_true { 'key_true' }
 		.key_type { 'key_type' }


### PR DESCRIPTION
Removal will happen in the next few days.

Part of #249 

> The `global` modifier for struct fields will stay for the foreseeable future.