### PR TITLE
(!) parser: require argument names in function types

### DIFF
--- a/cli/tools/ast/print_ast.bt
+++ b/cli/tools/ast/print_ast.bt
@@ -39,7 +39,7 @@ fun main() {
 	p.init(text, path, '')
 	file_ast := p.parse_result() or {
 		p.warnings.print()
-		p.error.print()
+		p.to_error(err).print()
 		exit(1)
 	}
 

--- a/docs/design/syntax.md
+++ b/docs/design/syntax.md
@@ -46,3 +46,19 @@ For details, I recommend reading https://futhark-lang.org/blog/2017-10-10-block-
 
 ### References
 - [GH-249 by @StunxFS](https://github.com/bait-lang/bait/issues/249)
+
+
+## Function Types
+Parameter names of function types must be named, e.g.
+```bait
+type Fetch := fun (method string, url string) []u8
+```
+
+### Benefits
+- **Improved Readability**:
+  - Purpose of each argument is easier to understand
+  - Reduced chance of parameter mix-ups
+- **Better tooling support and documentation**
+
+### Alternatives considered
+- `type Fetch := fun (string, string) []u8`

--- a/lib/bait/parser/expr.bt
+++ b/lib/bait/parser/expr.bt
@@ -114,7 +114,7 @@ fun (mut p Parser) array_init() !ast.ArrayInit{
 	// Type init, e.g. `[]i32`
 	if p.tok == .rsqr {
 		p.next()
-		elem_type := p.parse_type()!
+		elem_type := p.parse_type() or { ast.PLACEHOLDER_TYPE }
 		typ := p.table.find_or_register_array(elem_type)
 
 		// Optional parameters, e.g. `[]i32{ length = 10 cap = 20 }`

--- a/lib/bait/parser/expr.bt
+++ b/lib/bait/parser/expr.bt
@@ -83,16 +83,14 @@ fun (mut p Parser) single_expr() !ast.Expr {
 			return p.typeof_expr()!
 		}
 		.error {
-			p.error(p.val)!
-			return ast.InvalidExpr{} as ast.Expr
+			return error(p.val)
 		}
 		else {
 			mut msg := 'invalid expression: kind = ${p.tok}'
 			if p.val.length > 0 {
 				msg += ', val = ${p.val}'
 			}
-			p.error(msg)!
-			return ast.InvalidExpr{} as ast.Expr
+			return error(msg)
 		}
 	}
 }
@@ -134,7 +132,7 @@ fun (mut p Parser) array_init() !ast.ArrayInit{
 				} else if key == 'cap' {
 					cap_expr = expr
 				} else {
-					p.error('invalid array init field: ${key}')!
+					return error('invalid array init field: ${key}')
 				}
 			}
 			p.check(.rcur)!
@@ -212,7 +210,7 @@ fun (mut p Parser) comptime_var() !ast.ComptimeVar{
 
 	if kind == .unknown {
 		// TODO add hint with valid ones
-		p.error('invalid comptime var `$${name}`')!
+		return error('invalid comptime var `$${name}`')
 	}
 
 	return ast.ComptimeVar{

--- a/lib/bait/parser/fun.bt
+++ b/lib/bait/parser/fun.bt
@@ -90,7 +90,7 @@ fun (mut p Parser) fun_decl() !ast.FunDecl{
 		sym := p.table.get_sym(params[0].typ)
 		// TODO move this error into checker
 		if lang == .bait and sym.has_method(name) {
-			p.error('Method "${name}" already exists on type "${sym.name}"')!
+			return error('Method "${name}" already exists on type "${sym.name}"')
 		}
 		sym.methods.push(node)
 	} else {

--- a/lib/bait/parser/parser.bt
+++ b/lib/bait/parser/parser.bt
@@ -31,7 +31,6 @@ pub struct Parser {
 	pub mut lexer lexer.Lexer
 	pub mut infos []errors.Message
 	pub mut warnings []errors.Message
-	pub mut error errors.Message
 }
 
 pub fun new(table ast.Table, sema_ctx &context.SemanticContext, pref preference.Prefs) Parser {
@@ -64,7 +63,7 @@ pub fun (mut p Parser) init(text string, path string, expected_pkg string) {
 
 pub fun (mut p Parser) parse() ast.File {
 	return p.parse_result() or {
-		p.file_error()
+		p.file_error(err)
 	}
 }
 
@@ -178,7 +177,7 @@ fun (mut p Parser) skip(tok token.Token) {
 
 fun (mut p Parser) check (expected token.Token) ! {
 	if p.tok != expected {
-		p.error('unexpected ${p.tok}, expecting ${expected}')!
+		return error('unexpected ${p.tok}, expecting ${expected}')
 	}
 	p.next()
 }
@@ -278,13 +277,13 @@ fun (mut p Parser) peek() token.Token {
 	return p.next_tok
 }
 
-fun (p Parser) file_error() ast.File {
+fun (p Parser) file_error(msg string) ast.File {
 	return ast.File{
 		path = p.path
 		pkg_name = p.pkg_name
 		infos = p.infos
 		warnings = p.warnings
-		errors = [p.error]
+		errors = [p.to_error(msg)]
 	}
 }
 
@@ -308,13 +307,12 @@ fun (mut p Parser) warn(msg string) {
 	})
 }
 
-fun (mut p Parser) error(msg string) ! {
-	p.error = errors.Message{
+pub fun (p Parser) to_error(msg string) errors.Message {
+	return errors.Message{
 		kind = .error
 		path = p.path
 		pos = p.pos
 		title = 'error'
 		msg = msg
 	}
-	return error('')
 }

--- a/lib/bait/parser/stmt.bt
+++ b/lib/bait/parser/stmt.bt
@@ -29,10 +29,7 @@ fun (mut p Parser) pub_stmt() !ast.Stmt {
 		.key_interface{ p.interface_decl()! }
 		.key_static { p.static_decl()! }
 		.key_struct{ p.struct_decl()! }
-		else{
-			p.error('cannot use pub keyword before ${p.peek()}')!
-			ast.InvalidStmt{}
-		}
+		else{ error('cannot use pub keyword before ${p.peek()}') }
 	}
 }
 
@@ -41,8 +38,7 @@ fun (mut p Parser) script_mode_or_error() !ast.Stmt {
 		return p.script_mode_main()!
 	}
 
-	p.error('bad toplevel token: kind = ${p.tok}, val = ${p.val}')!
-	return ast.InvalidStmt{}
+	return error('bad toplevel token: kind = ${p.tok}, val = ${p.val}')
 }
 
 fun (mut p Parser) script_mode_main() !ast.FunDecl {
@@ -318,7 +314,7 @@ fun (mut p Parser) interface_decl() !ast.InterfaceDecl{
 		f_is_global := p.tok == .key_global
 		if f_is_global {
 			if f_is_pub or f_is_mut {
-				p.error('unexpected `global`')!
+				return error('unexpected `global`')
 			}
 			p.next()
 		}

--- a/lib/bait/parser/struct.bt
+++ b/lib/bait/parser/struct.bt
@@ -34,7 +34,7 @@ fun (mut p Parser) struct_decl() !ast.StructDecl{
 		f_is_global := p.tok == .key_global
 		if f_is_global {
 			if f_is_pub or f_is_mut {
-				p.error('unexpected `global`')!
+				return error('unexpected `global`')
 			}
 			p.next()
 		}

--- a/lib/bait/parser/type.bt
+++ b/lib/bait/parser/type.bt
@@ -136,7 +136,7 @@ fun (mut p Parser) parse_map_type() !ast.Type {
 	p.check(.lsqr)!
 	key_type := p.parse_type()!
 	if key_type != ast.STRING_TYPE {
-		p.error('map key type must be string')!
+		return error('map key type must be string')
 	}
 	p.check(.rsqr)!
 	val_type := p.parse_type()!
@@ -153,10 +153,10 @@ fun (mut p Parser) generic_type_names() ![]string {
 	for true {
 		name := p.check_name()!
 		if name.length > 1 {
-			p.error('generic types names have to be exactly one character')!
+			return error('generic types names have to be exactly one character')
 		}
 		if not name[0].is_upper() {
-			p.error('generic type names have to be capital letters')!
+			return error('generic type names have to be capital letters')
 		}
 		names.push(name)
 

--- a/lib/bait/parser/type.bt
+++ b/lib/bait/parser/type.bt
@@ -37,7 +37,7 @@ fun (mut p Parser) parse_type() !ast.Type {
 	if p.tok == .lsqr{
 		p.next()
 		p.check(.rsqr)!
-		elem_type := p.parse_type()!
+		elem_type := p.parse_type() or { ast.PLACEHOLDER_TYPE }
 		return p.table.find_or_register_array(elem_type)
 	}
 
@@ -67,10 +67,6 @@ fun (mut p Parser) parse_type() !ast.Type {
 }
 
 fun (mut p Parser) parse_name_type(lang ast.Language) !ast.Type {
-	if p.tok != .name {
-		return ast.PLACEHOLDER_TYPE
-	}
-
 	mut name := lang.prepend_to(p.check_name()!)
 
 	// Build full name and handle imported types
@@ -114,6 +110,11 @@ fun (mut p Parser) parse_fun_type() !ast.Type {
 	p.check(.lpar)!
 	mut param_types := []ast.Type
 	for p.tok != .rpar{
+		if p.peek() != .rpar {
+			_ = p.check_name()! // Require argument name but ignore it for now
+		} else {
+			p.warn("expected argument name")
+		}
 		typ := p.parse_type()!
 		param_types.push(typ)
 		if p.tok != .rpar{


### PR DESCRIPTION
Breaking change. 

Old:
```
type CheckInt := fun (i32) bool
```

New:
```
type CheckInt := fun (i i32) bool
```