### PR TITLE
checker,gen: fix nested generic calls with different parameter signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes are documented in this file.
 - gen: do not generate main call in script mode
 - gen: Handle more expressions in failed asserts
 - checker: fix number promotion in function call arguments
+- checker,gen: fix stale concrete types on shared generic call nodes, which made nested generic calls dispatch to the wrong instantiation
 - remove `test-all` tool
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,9 @@ All notable changes are documented in this file.
 - gen: do not generate main call in script mode
 - gen: Handle more expressions in failed asserts
 - checker: fix number promotion in function call arguments
-- checker,gen: fix stale concrete types on shared generic call nodes, which made nested generic calls dispatch to the wrong instantiation
+- Generics:
+  - fix stale concrete types on shared generic call nodes
+  - resolve concrete types of nested generic calls in the correct order
 - remove `test-all` tool
 
 

--- a/lib/bait/ast/ast.bt
+++ b/lib/bait/ast/ast.bt
@@ -205,12 +205,31 @@ pub struct CallExpr {
 	global left_type Type
 	global left Expr := InvalidExpr{}
 	global concrete_types []Type
+	global inst_types map[string][]Type
 	global is_field bool
 	global noreturn bool
 	global args []CallArg
 	global or_block OrBlock
 	pub is_method bool
 	pub pos token.Pos
+}
+
+// inst_key returns a unique key for a concrete types instantiation, used to
+// store and look up the resolved concrete types of nested generic calls.
+pub fun inst_key(concrete []Type) string {
+	mut key := ""
+	for t in concrete {
+		key += '${t.idx()}_'
+	}
+	return key
+}
+
+pub fun (mut node CallExpr) register_inst_types(key string, conc []Type) {
+	mut copy := []Type
+	for t in conc {
+		copy.push(t)
+	}
+	node.inst_types[key] = copy
 }
 
 pub fun (node CallExpr) full_name() string {

--- a/lib/bait/ast/table.bt
+++ b/lib/bait/ast/table.bt
@@ -63,7 +63,13 @@ pub fun (mut t Table) register_concrete(key string, concrete []Type) bool {
 		return false
 	}
 
-	t.generic_fun_types[key].push(concrete)
+	// Store a copy: `concrete` is often a call node's `concrete_types` field,
+	// which later checker passes overwrite in place.
+	mut copy := []Type
+	for typ in concrete {
+		copy.push(typ)
+	}
+	t.generic_fun_types[key].push(copy)
 	return true
 }
 

--- a/lib/bait/checker/fun.bt
+++ b/lib/bait/checker/fun.bt
@@ -356,30 +356,12 @@ fun (mut c Checker) call_args(mut node ast.CallExpr, poffset i32, generic_names 
 	// concrete types from a previous pass, so always re-resolve those calls.
 	should_resolve_generics := generic_names.length != node.concrete_types.length
 		or c.cur_concrete_types.length > 0
-	mut save_as_concrete := false
+	mut resolved := []ast.Type{length = generic_names.length}
 
 	for i, mut arg in node.args {
 		param := params[i + poffset]
 		mut param_type := param.typ
 		psym := c.table.get_sym(param_type)
-
-		if should_resolve_generics and psym.kind == .generic {
-			gi := generic_names.index(psym.mix_name)
-			// Generic fun bodies are re-checked once per concrete instantiation on
-			// shared AST nodes: overwrite entries left behind by previous passes.
-			if gi < c.cur_concrete_types.length {
-				conc := c.cur_concrete_types[gi]
-				if gi < node.concrete_types.length {
-					node.concrete_types[gi] = conc
-				} else {
-					node.concrete_types.push(conc)
-				}
-			} else if gi < node.concrete_types.length {
-				param_type = node.concrete_types[gi]
-			} else {
-				save_as_concrete = true
-			}
-		}
 
 		c.expected_type = param_type
 		arg.typ = c.expr(arg.expr)
@@ -387,9 +369,32 @@ fun (mut c Checker) call_args(mut node ast.CallExpr, poffset i32, generic_names 
 			continue
 		}
 
-		if save_as_concrete {
-			node.concrete_types.push(arg.typ)
-			save_as_concrete = false
+		if should_resolve_generics and psym.kind == .generic {
+			gi := generic_names.index(psym.mix_name)
+			// Resolve the concrete type from the actual argument binding:
+			// `gi` indexes the callee's generic names, while
+			// `c.cur_concrete_types` follows the enclosing fun's order,
+			// so indexing it with `gi` alone yields the wrong type when the
+			// generic parameters are passed in a different order.
+			arg_sym := c.table.get_sym(arg.typ)
+			if arg_sym.kind == .generic {
+				pi := c.cur_fun.generic_names.index(arg_sym.mix_name)
+				if pi >= 0 and pi < c.cur_concrete_types.length {
+					arg.typ = c.cur_concrete_types[pi]
+				}
+			}
+			// A generic name bound to several parameters stays consistent.
+			if resolved[gi] == 0 {
+				resolved[gi] = arg.typ
+				// Generic fun bodies are re-checked once per concrete instantiation on
+				// shared AST nodes: overwrite entries left behind by previous passes.
+				if gi < node.concrete_types.length {
+					node.concrete_types[gi] = arg.typ
+				} else {
+					node.concrete_types.push(arg.typ)
+				}
+			}
+			param_type = resolved[gi]
 		}
 
 		if not c.check_types(arg.typ, param_type) {
@@ -418,6 +423,12 @@ fun (mut c Checker) call_args(mut node ast.CallExpr, poffset i32, generic_names 
 				c.error('add `mut` to argument for parameter `${param.name}`', expr.pos)
 			}
 		}
+	}
+
+	if c.cur_concrete_types.length > 0 {
+		// Record the resolved types for the gen backend, which re-walks the
+		// fun body once per instantiation without access to argument bindings.
+		node.register_inst_types(ast.inst_key(c.cur_concrete_types), node.concrete_types)
 	}
 }
 

--- a/lib/bait/checker/fun.bt
+++ b/lib/bait/checker/fun.bt
@@ -352,7 +352,10 @@ fun (mut c Checker) set_conc_types(mut node ast.CallExpr, generic_names []string
 
 // TODO clean this up
 fun (mut c Checker) call_args(mut node ast.CallExpr, poffset i32, generic_names []string, params []ast.Param) {
+	// Inside a generic instantiation the shared AST node may already hold
+	// concrete types from a previous pass, so always re-resolve those calls.
 	should_resolve_generics := generic_names.length != node.concrete_types.length
+		or c.cur_concrete_types.length > 0
 	mut save_as_concrete := false
 
 	for i, mut arg in node.args {
@@ -362,10 +365,17 @@ fun (mut c Checker) call_args(mut node ast.CallExpr, poffset i32, generic_names 
 
 		if should_resolve_generics and psym.kind == .generic {
 			gi := generic_names.index(psym.mix_name)
-			if gi < node.concrete_types.length {
+			// Generic fun bodies are re-checked once per concrete instantiation on
+			// shared AST nodes: overwrite entries left behind by previous passes.
+			if gi < c.cur_concrete_types.length {
+				conc := c.cur_concrete_types[gi]
+				if gi < node.concrete_types.length {
+					node.concrete_types[gi] = conc
+				} else {
+					node.concrete_types.push(conc)
+				}
+			} else if gi < node.concrete_types.length {
 				param_type = node.concrete_types[gi]
-			} else if gi < c.cur_concrete_types.length {
-				node.concrete_types.push(c.cur_concrete_types[gi])
 			} else {
 				save_as_concrete = true
 			}

--- a/lib/bait/gen/c/fun.bt
+++ b/lib/bait/gen/c/fun.bt
@@ -121,10 +121,13 @@ fun (mut g Gen) call_expr(node ast.CallExpr) {
 	if node.concrete_types.length > 0 {
 		// Inside a generic instantiation, `node.concrete_types` holds whatever the
 		// last checker pass left behind on the shared AST node: resolve the inner
-		// call name from the concrete types of the current pass instead.
+		// call name from the types recorded for the current instantiation instead.
 		mut conc_types := node.concrete_types
 		if g.cur_concrete_types.length > 0 {
-			conc_types = g.cur_concrete_types.values()[..node.concrete_types.length]
+			key := ast.inst_key(g.cur_concrete_types.values())
+			if node.inst_types.contains(key) {
+				conc_types = node.inst_types[key]
+			}
 		}
 		name = g.get_concrete_name(name, conc_types)
 	}

--- a/lib/bait/gen/c/fun.bt
+++ b/lib/bait/gen/c/fun.bt
@@ -119,7 +119,14 @@ fun (mut g Gen) call_expr(node ast.CallExpr) {
 	}
 
 	if node.concrete_types.length > 0 {
-		name = g.get_concrete_name(name, node.concrete_types)
+		// Inside a generic instantiation, `node.concrete_types` holds whatever the
+		// last checker pass left behind on the shared AST node: resolve the inner
+		// call name from the concrete types of the current pass instead.
+		mut conc_types := node.concrete_types
+		if g.cur_concrete_types.length > 0 {
+			conc_types = g.cur_concrete_types.values()[..node.concrete_types.length]
+		}
+		name = g.get_concrete_name(name, conc_types)
 	}
 
 	g.write(name)

--- a/lib/bait/gen/js/fun.bt
+++ b/lib/bait/gen/js/fun.bt
@@ -132,7 +132,14 @@ fun (mut g Gen) call_expr_no_or(node ast.CallExpr) {
 	}
 
 	if node.concrete_types.length > 0 {
-		name = g.get_concrete_name(name, node.concrete_types)
+		// Inside a generic instantiation, `node.concrete_types` holds whatever the
+		// last checker pass left behind on the shared AST node: resolve the inner
+		// call name from the concrete types of the current pass instead.
+		mut conc_types := node.concrete_types
+		if g.cur_concrete_types.length > 0 {
+			conc_types = g.cur_concrete_types.values()[..node.concrete_types.length]
+		}
+		name = g.get_concrete_name(name, conc_types)
 	}
 
 	g.write(name)

--- a/lib/bait/gen/js/fun.bt
+++ b/lib/bait/gen/js/fun.bt
@@ -134,10 +134,13 @@ fun (mut g Gen) call_expr_no_or(node ast.CallExpr) {
 	if node.concrete_types.length > 0 {
 		// Inside a generic instantiation, `node.concrete_types` holds whatever the
 		// last checker pass left behind on the shared AST node: resolve the inner
-		// call name from the concrete types of the current pass instead.
+		// call name from the types recorded for the current instantiation instead.
 		mut conc_types := node.concrete_types
 		if g.cur_concrete_types.length > 0 {
-			conc_types = g.cur_concrete_types.values()[..node.concrete_types.length]
+			key := ast.inst_key(g.cur_concrete_types.values())
+			if node.inst_types.contains(key) {
+				conc_types = node.inst_types[key]
+			}
 		}
 		name = g.get_concrete_name(name, conc_types)
 	}

--- a/tests/generics/dispatch_test.bt
+++ b/tests/generics/dispatch_test.bt
@@ -9,10 +9,27 @@ fun outer_type_name[T](v T) string {
 	return inner_type_name(v)
 }
 
+fun swap_inner[A, B](a A, b B) string {
+	return typeof(a) + '_' + typeof(b)
+}
+
+fun swap_outer[T, U](t T, u U) string {
+	return swap_inner(u, t)
+}
+
 fun test_nested_generic_dispatch() {
 	// The string instantiation runs first: the later instantiations must not
 	// reuse the inner call types inferred during the first pass.
 	assert outer_type_name('hi') == 'string'
 	assert outer_type_name(42) == 'i32'
 	assert outer_type_name(true) == 'bool'
+}
+
+fun test_nested_generic_dispatch_reordered() {
+	// The inner call passes its arguments in a different order than the
+	// enclosing fun's generic parameters: the concrete types of the inner
+	// call must be resolved from the argument bindings, not from the
+	// position of the generic parameter in the enclosing fun.
+	assert swap_outer('hi', 42) == 'i32_string'
+	assert swap_outer(42, 'hi') == 'string_i32'
 }

--- a/tests/generics/dispatch_test.bt
+++ b/tests/generics/dispatch_test.bt
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Lukas Neubert <lukas.neubert@proton.me>
+// SPDX-License-Identifier: MIT
+
+fun inner_type_name[V](v V) string {
+	return typeof(v)
+}
+
+fun outer_type_name[T](v T) string {
+	return inner_type_name(v)
+}
+
+fun test_nested_generic_dispatch() {
+	// The string instantiation runs first: the later instantiations must not
+	// reuse the inner call types inferred during the first pass.
+	assert outer_type_name('hi') == 'string'
+	assert outer_type_name(42) == 'i32'
+	assert outer_type_name(true) == 'bool'
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nested generic calls incorrectly reusing concrete types from previous instantiations.
  * Improved dispatch accuracy when generic arguments are swapped or reused across successive calls.

* **Tests**
  * Added coverage for nested generic type reporting and argument-order-dependent dispatch.
  * Verified correct resolution for string, integer, and Boolean instantiations.

* **Documentation**
  * Documented the generic dispatch correction in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->